### PR TITLE
[Fix]탭바-하위요소 있는 탭이 선택되었을 때만 탭바 높이 조정하도록 수정

### DIFF
--- a/src/shared/components/NavLink.tsx
+++ b/src/shared/components/NavLink.tsx
@@ -18,12 +18,11 @@ function NavLink({
 }) {
   const pathname = usePathname();
   const isActive = pathname === href;
-
   return (
     <li
       className={`${
         tabBar
-          ? type === "mypage" && isActive
+          ? type === "mypage" && isActive && children
             ? "w-1/5 h-30"
             : "w-1/5 h-15"
           : ""

--- a/src/shared/components/TabBar.tsx
+++ b/src/shared/components/TabBar.tsx
@@ -21,9 +21,9 @@ function TabBar({
     <ul className="w-full h-fit flex justify-start items-baseline">
       {tabContents.map(({ href, name, children }) => (
         <NavLink key={href} href={href} name={name} tabBar type={type}>
-          <ul className="flex top-15 left-1/2 -translate-x-1/2 absolute">
-            {children &&
-              children.map(({ href, name }) => (
+          {children && (
+            <ul className="flex top-15 left-1/2 -translate-x-1/2 absolute">
+              {children.map(({ href, name }) => (
                 <li key={href}>
                   <Link
                     href={href}
@@ -35,7 +35,8 @@ function TabBar({
                   </Link>
                 </li>
               ))}
-          </ul>
+            </ul>
+          )}
         </NavLink>
       ))}
     </ul>


### PR DESCRIPTION
### 🛠️ 작업 개요
탭바에서 하위요소가 있는 탭이 선택되었을때만 탭바의 높이가 늘어나도록 수정했습니다.

### ✏️ 작업 내용
마이페이지 탭바에서 하위요소가 없는 탭이 선택되었을때도 하위요소만큼의 공간을 추가로 차지하고 있는 문제가 있었는데 하위요소가 있는 탭이 선택되었을때만 탭바의 높이가 늘어나도록 설정했습니다

### #️⃣ 관련 이슈

### 🗣️ 테스트 결과 보고
