### PR TITLE
fix: 배포환경 CSP 오류 해결(middleware+nonce 적용)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,30 +35,5 @@ const nextConfig: NextConfig = {
 			},
 		];
 	},
-	async headers() {
-		return [
-			{
-				source: "/(.*)",
-				headers: [
-					{
-						key: "Content-Security-Policy",
-						value: `
-              default-src 'self';
-              script-src 'self' ${isDev ? "'unsafe-eval' 'unsafe-inline'" : ""};
-              style-src 'self' ${isDev ? "'unsafe-inline'" : ""};
-              img-src 'self' data: https:;
-              connect-src 'self';
-              font-src 'self';
-              object-src 'none';
-              base-uri 'none';
-              frame-ancestors 'none';
-            `
-							.replace(/\s{2,}/g, " ")
-							.trim(),
-					},
-				],
-			},
-		];
-	},
 };
 export default nextConfig;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function toBase64Url(bytes: Uint8Array) {
+	const base64 = Buffer.from(bytes).toString("base64");
+	return base64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+export function middleware(req: NextRequest) {
+	const nonceBytes = crypto.getRandomValues(new Uint8Array(16));
+	const nonce = toBase64Url(nonceBytes);
+
+	const csp = [
+		"default-src 'self'",
+		"base-uri 'self'",
+		"object-src 'none'",
+
+		`script-src 'self' 'nonce-${nonce}' https://www.clarity.ms https://scripts.clarity.ms`,
+
+		`style-src 'self' 'unsafe-inline' `,
+
+		"img-src 'self' data: https:",
+
+		"font-src 'self' data:",
+
+		"connect-src 'self' https:",
+
+		"frame-ancestors 'none'",
+	].join("; ");
+
+	//requestHeader에 함께 첨부
+	const requestHeaders = new Headers(req.headers);
+	requestHeaders.set("Content-Security-Policy", csp);
+	requestHeaders.set("x-nonce", nonce);
+
+	const response = NextResponse.next({
+		request: {
+			headers: requestHeaders,
+		},
+	});
+
+	//response에서도 확인
+	response.headers.set("Content-Security-Policy", csp);
+	response.headers.set("x-nonce", nonce);
+
+	return response;
+}
+
+export const config = {
+	matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
### 🛠️ 작업 개요

기존 CSP(next.config.ts의 header에서 정적으로 설정)는 개발 환경에서 정상 동작했으나 배포환경에서는 과도하게 엄격하게 적용되어 inline script/style 관련 CSP 에러가 발생

### ✏️ 작업 내용

CSP 설정을 next.config.ts에서 제거
middleware 기반으로 CSP를 설정하여 요청단위로 nonce 적용
script-src는 nonce 기반으로 엄격한 규칙 적용
style-src는 동적 UI 처리를 위해 unsafe-inline 허용
clarity 사용을 위해 관련 도메인을 CSP에 명시적으로 허용

⚠️ 주의 사항
CSP가 엄격하게 적용되므로,
외부 라이브러리(analytics, widget, SDK 등)를 추가로 사용하는 경우
해당 라이브러리가 로드하는 외부 script 도메인을 CSP에 명시적으로 허용해야 합니다.
clarity 역시 이 규칙에 따라 도메인을 whitelist에 추가했습니다.
예시
```
//src/middleware.ts
const csp =[
     `script-src 'self' 'nonce-${nonce}' https://www.clarity.ms https://scripts.clarity.ms`,
]
```

### #️⃣ 관련 이슈

### 🗣️ 테스트 결과 보고

<!-- 테스트 결과나 내용 기입 -->
